### PR TITLE
Changed path to config file

### DIFF
--- a/src/Http/Middleware/ScaffoldMiddleware.php
+++ b/src/Http/Middleware/ScaffoldMiddleware.php
@@ -25,7 +25,7 @@ class ScaffoldMiddleware
         if ($request->segment(1) == 'scaffold') {
 
             // allowed env-s check
-            $allowed = collect(config('scaffold.env'))
+            $allowed = collect(config('amranidev.config.env'))
                             ->contains(config('app.env'));
 
             if (!$allowed) {


### PR DESCRIPTION
Changed path to config file as it pointed to "scaffold.env" instead of "amranidev.config.env".

The ScaffoldMiddleware isn't used in the project so the directory scaffold is accessible on production sites.
Maybe you could mention it in the Readme and explain that:
'scaffold' => \Amranidev\ScaffoldInterface\Http\Middleware\ScaffoldMiddleware::class,
should be added to $routeMiddleware in App/Http/Kernel.php
and use it in routes like:
Route::group(['middleware' => ['web', 'scaffold']], function () {...